### PR TITLE
Fix Cloud Deploy pipeline promotion

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -83,6 +83,30 @@ steps:
       - '--from-run-manifest=service-prd.yaml'
       - '--description=automated release'
 
+  # 7. Promote release to staging
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'deploy'
+      - 'releases'
+      - 'promote'
+      - 'release-${_BUILD_ID}'
+      - '--delivery-pipeline=flask-pipeline'
+      - '--region=us-central1'
+      - '--to-target=stg'
+
+  # 8. Promote release to production
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'deploy'
+      - 'releases'
+      - 'promote'
+      - 'release-${_BUILD_ID}'
+      - '--delivery-pipeline=flask-pipeline'
+      - '--region=us-central1'
+      - '--to-target=prd'
+
 options:
   logging: CLOUD_LOGGING_ONLY
 

--- a/service-dev.yaml
+++ b/service-dev.yaml
@@ -11,7 +11,7 @@ spec:
         deploy.cloud.google.com/target: "dev"
     spec:
       containers:
-        - image: us-central1-docker.pkg.dev/silent-octagon-460701-a0/project4-dev/dev:latest
+        - image: dev
       serviceAccountName: shopshere-product-service@silent-octagon-460701-a0.iam.gserviceaccount.com
       ports:
         - containerPort: 8080

--- a/service-prd.yaml
+++ b/service-prd.yaml
@@ -11,7 +11,7 @@ spec:
         deploy.cloud.google.com/target: "prd"
     spec:
       containers:
-        - image: us-central1-docker.pkg.dev/silent-octagon-460701-a0/project4-prd/prd:latest
+        - image: prd
       serviceAccountName: shopshere-product-service@silent-octagon-460701-a0.iam.gserviceaccount.com
       ports:
         - containerPort: 8080

--- a/service-stg.yaml
+++ b/service-stg.yaml
@@ -11,7 +11,7 @@ spec:
         deploy.cloud.google.com/target: "stg"
     spec:
       containers:
-        - image: us-central1-docker.pkg.dev/silent-octagon-460701-a0/project4-stg/stg:latest
+        - image: stg
       serviceAccountName: shopshere-product-service@silent-octagon-460701-a0.iam.gserviceaccount.com
       ports:
         - containerPort: 8080


### PR DESCRIPTION
## Summary
- replace container image URIs in Cloud Run service manifests with image placeholders used by Cloud Deploy
- add auto-promotion steps for staging and production in the Cloud Build config

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6865c441b820832b95c418500d8bd0d1