### PR TITLE
Fix gcloud promote argument

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -90,7 +90,7 @@ steps:
       - 'deploy'
       - 'releases'
       - 'promote'
-      - 'release-${_BUILD_ID}'
+      - '--release=release-${_BUILD_ID}'
       - '--delivery-pipeline=flask-pipeline'
       - '--region=us-central1'
       - '--to-target=stg'
@@ -102,7 +102,7 @@ steps:
       - 'deploy'
       - 'releases'
       - 'promote'
-      - 'release-${_BUILD_ID}'
+      - '--release=release-${_BUILD_ID}'
       - '--delivery-pipeline=flask-pipeline'
       - '--region=us-central1'
       - '--to-target=prd'
@@ -112,5 +112,3 @@ options:
 
 substitutions:
   _BUILD_ID: $BUILD_ID
-
-#test

--- a/service-dev.yaml
+++ b/service-dev.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "dev"
+        run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:
         - image: dev

--- a/service-prd.yaml
+++ b/service-prd.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "prd"
+        run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:
         - image: prd

--- a/service-stg.yaml
+++ b/service-stg.yaml
@@ -9,6 +9,7 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "stg"
+        run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:
         - image: stg


### PR DESCRIPTION
## Summary
- fix Cloud Build pipeline `promote` steps to pass `--release`
- add revision suffix annotations so each deployment revision is unique

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865c6f58198832b9f64f1308de6130b