### PR TITLE
Fix Cloud Deploy target annotation

### DIFF
--- a/service-dev.yaml
+++ b/service-dev.yaml
@@ -9,6 +9,8 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "dev"
+        deploy.cloud.google.com/delivery-pipeline: "flask-pipeline"
+        deploy.cloud.google.com/location: "us-central1"
         run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:

--- a/service-prd.yaml
+++ b/service-prd.yaml
@@ -9,6 +9,8 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "prd"
+        deploy.cloud.google.com/delivery-pipeline: "flask-pipeline"
+        deploy.cloud.google.com/location: "us-central1"
         run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:

--- a/service-stg.yaml
+++ b/service-stg.yaml
@@ -9,6 +9,8 @@ spec:
       annotations:
         run.googleapis.com/client-name: "cloud-deploy"
         deploy.cloud.google.com/target: "stg"
+        deploy.cloud.google.com/delivery-pipeline: "flask-pipeline"
+        deploy.cloud.google.com/location: "us-central1"
         run.googleapis.com/revision-suffix: "${_BUILD_ID}"
     spec:
       containers:


### PR DESCRIPTION
## Summary
- add delivery pipeline and location annotations to Cloud Run manifests so each target uses its correct service and image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d2665760832bbf3e335a7da6df24