### PR TITLE
Fix Cloud Run namespace

### DIFF
--- a/cloudrun-dev.yaml
+++ b/cloudrun-dev.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-dev
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:

--- a/cloudrun-prd.yaml
+++ b/cloudrun-prd.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-prd
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:

--- a/cloudrun-stg.yaml
+++ b/cloudrun-stg.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-stg
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:

--- a/service-dev.yaml
+++ b/service-dev.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-dev
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:

--- a/service-prd.yaml
+++ b/service-prd.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-prd
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:

--- a/service-stg.yaml
+++ b/service-stg.yaml
@@ -2,7 +2,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: python-web-flask-stg
-  namespace: default
+  namespace: silent-octagon-460701-a0
 spec:
   template:
     metadata:


### PR DESCRIPTION
## Summary
- fix `namespace` field in all Cloud Run service manifests

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68661748c718832bb13b099f2331d90e